### PR TITLE
Accept a hashed password on Auth::getMobileSession

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -34,16 +34,17 @@ class Auth {
 	 *
 	 * @param	string	$username	The last.fm username. (Required)
 	 * @param	string	$password	The last.fm password. (Required)
+     * @param   bool    $apply_md5  Set to false if the supplied password has already been hashed. (Optional)
 	 * @return	Session				A Session object.
 	 *
 	 * @static
 	 * @access	public
 	 * @throws	Error
 	 */
-	public static function getMobileSession($username, $password){
+	public static function getMobileSession($username, $password, $apply_md5 = true){
 		$xml = CallerFactory::getDefaultCaller()->signedCall('auth.getMobileSession', array(
 			'username'  => $username,
-			'authToken' => md5($username . md5($password))
+			'authToken' => md5($username . (($apply_md5) ? md5($password) : $password))
 		));
 
 		return Session::fromSimpleXMLElement($xml);


### PR DESCRIPTION
In some scenarios you might all ready have a hashed password and you don't want it to be hashed again within the method. I've added an additional, optional parameter to the Auth::getMobileSession method. When set to false it will not hash the password.
It defaults to true, to make sure it's backwards compatible.

PS: I know this PR is long overdue ;)
