### PR TITLE
using spl_autoload_register instead of __autoload for compatibility

### DIFF
--- a/src/lastfm.api.php
+++ b/src/lastfm.api.php
@@ -6,7 +6,7 @@
  * @author  Felix Bruns <felixbruns@web.de>
  * @version	1.0
  */
-function __autoload($name){
+function lastfm_autoload($name){
 	if(stripos($name, 'Cache') !== false){
 		$filename = realpath(sprintf("%s/cache/%s.php", dirname(__FILE__), $name));
 	}
@@ -29,4 +29,4 @@ function __autoload($name){
 	}
 }
 
-
+spl_autoload_register('lastfm_autoload');


### PR DESCRIPTION
A quick fix for the bigger problem of the project not being PSR-0. PSR standards didn't exist when it was written so no hard feelings. I might come back soon and PSR-0 the hell out of it :)
